### PR TITLE
Escape special characters in JSON before PDF rendering

### DIFF
--- a/src/main/java/com/example/reporting/report/ReportGenerator.java
+++ b/src/main/java/com/example/reporting/report/ReportGenerator.java
@@ -377,6 +377,9 @@ public class ReportGenerator {
                 case '\n' -> sb.append("\\n");
                 case '\r' -> sb.append("\\r");
                 case '\t' -> sb.append("\\t");
+                case '<' -> sb.append("\\u003c");
+                case '>' -> sb.append("\\u003e");
+                case '&' -> sb.append("\\u0026");
                 default -> {
                     if (c < 0x20) {
                         sb.append(String.format("\\u%04x", (int) c));


### PR DESCRIPTION
## Summary
- escape additional characters when encoding JSON for embedding in the HTML report so that generated XHTML remains valid for PDF rendering

## Testing
- mvn -q -DskipTests package *(fails: Maven Central access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e4fba7e5988325afefff11393cf400