### PR TITLE
Fix invalid data-scroll attribute in navigation links

### DIFF
--- a/src/main/java/com/example/reporting/report/ReportGenerator.java
+++ b/src/main/java/com/example/reporting/report/ReportGenerator.java
@@ -429,7 +429,7 @@ public class ReportGenerator {
     }
 
     private String renderNavItem(String id, String label) {
-        return String.format("<li><a href=\"#%s\" data-scroll>%s</a></li>", escapeHtml(id), escapeHtml(label));
+        return String.format("<li><a href=\"#%s\" data-scroll=\"true\">%s</a></li>", escapeHtml(id), escapeHtml(label));
     }
 
     private String renderOverviewCard() {


### PR DESCRIPTION
## Summary
- add an explicit value to the data-scroll attribute so the generated HTML is valid XML for the PDF renderer

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_b_68e500e276408325a635ca4477cfa066