### PR TITLE
Fix invalid selector quoting in panel lookup

### DIFF
--- a/src/main/java/com/example/reporting/report/ReportGenerator.java
+++ b/src/main/java/com/example/reporting/report/ReportGenerator.java
@@ -634,7 +634,7 @@ public class ReportGenerator {
         script.append("      if (activeButton) { activeButton.focus(); }\n");
         script.append("    }\n");
         script.append("    setTimeout(() => {\n");
-        script.append("      const panel = document.querySelector('[data-tab-panel=\\"' + id + '\\"]');\n");
+        script.append("      const panel = document.querySelector(\"[data-tab-panel='" + id + "']\");\n");
         script.append("      if (panel) {\n");
         script.append("        panel.querySelectorAll('table').forEach(table => {\n");
         script.append("          const instance = dataTables[table.id];\n");


### PR DESCRIPTION
## Summary
- update the generated JavaScript selector to use consistent double-quote escaping and avoid Java compilation errors

## Testing
- javac -cp src/main/java $(find src/main/java -name '*.java') *(fails: missing external dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68e50706637083259d17b6f42b3f92c1