### PR TITLE
Fix unresolved id variable in tab panel selector

### DIFF
--- a/src/main/java/com/example/reporting/report/ReportGenerator.java
+++ b/src/main/java/com/example/reporting/report/ReportGenerator.java
@@ -634,7 +634,7 @@ public class ReportGenerator {
         script.append("      if (activeButton) { activeButton.focus(); }\n");
         script.append("    }\n");
         script.append("    setTimeout(() => {\n");
-        script.append("      const panel = document.querySelector(\"[data-tab-panel='" + id + "']\");\n");
+        script.append("      const panel = document.querySelector(`[data-tab-panel='${id}']`);\n");
         script.append("      if (panel) {\n");
         script.append("        panel.querySelectorAll('table').forEach(table => {\n");
         script.append("          const instance = dataTables[table.id];\n");


### PR DESCRIPTION
## Summary
- update the generated report script to embed the tab identifier via a JavaScript template literal instead of a Java variable reference
- ensure the tab panel lookup remains functional without causing a Java compilation error

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returned HTTP 403 during plugin resolution in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e5084220ac8325896d99dd95936c22