### PR TITLE
Add Log4j-to-SLF4J bridge dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
             <artifactId>logback-classic</artifactId>
             <version>1.4.11</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+            <version>2.20.0</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
## Summary
- add the log4j-to-slf4j dependency so Log4j loggers delegate to the existing SLF4J/Logback setup

## Testing
- mvn -q -e -DskipTests compile *(fails: maven central blocked 403)*

------
https://chatgpt.com/codex/tasks/task_b_68e50edc39188325b18fb3cad23d0412