### PR TITLE
Replace tab buttons with spans for PDF compatibility

### DIFF
--- a/src/main/java/com/example/reporting/report/ReportGenerator.java
+++ b/src/main/java/com/example/reporting/report/ReportGenerator.java
@@ -453,7 +453,7 @@ public class ReportGenerator {
         String buttonId = "tab-" + id;
         return String.format(
                 Locale.ROOT,
-                "<button type=\"button\" class=\"tab-link\" role=\"tab\" id=\"%s\" data-tab=\"%s\" aria-controls=\"%s\" aria-selected=\"false\" tabindex=\"-1\">%s</button>",
+                "<span class=\"tab-link\" role=\"tab\" id=\"%s\" data-tab=\"%s\" aria-controls=\"%s\" aria-selected=\"false\" tabindex=\"-1\">%s</span>",
                 escapeHtml(buttonId),
                 escapeHtml(id),
                 escapeHtml(id),


### PR DESCRIPTION
## Summary
- replace the report navigation buttons with span elements so the PDF renderer no longer logs warnings about form controls without forms

## Testing
- `mvn -q -DskipTests package` *(fails: unable to download maven-resources-plugin because Maven Central returned 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68e510b5d89483259f20b286713ac121