### PR TITLE
Fix navigation tabs by removing CDATA wrapper from inline script

### DIFF
--- a/src/main/java/com/example/reporting/report/ReportGenerator.java
+++ b/src/main/java/com/example/reporting/report/ReportGenerator.java
@@ -206,7 +206,7 @@ public class ReportGenerator {
                 .append("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/pdfmake.min.js\"></script>")
                 .append("<script src=\"https://cdnjs.cloudflare.com/ajax/libs/pdfmake/0.2.7/vfs_fonts.js\"></script>")
                 .append("<script src=\"https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js\"></script>")
-                .append("<script type=\"text/javascript\"><![CDATA[")
+                .append("<script type=\"text/javascript\">")
                 .append("const reportSections = ").append(toJsonSections()).append(";")
                 .append("const abnormalIdsColumns = ").append(toJsonArray(abnormalColumns)).append(";")
                 .append("const abnormalIdsData = ").append(abnormalJson).append(";")
@@ -221,7 +221,7 @@ public class ReportGenerator {
                 .append("const sdErrorDetailColumns = ").append(toJsonArray(sdErrorDetailColumns)).append(";")
                 .append("const sdErrorDetailData = ").append(sdErrorDetailJson).append(";")
                 .append(getScript())
-                .append("]]></script>");
+                .append("</script>");
 
         html.append("</body></html>");
         return html.toString();


### PR DESCRIPTION
## Summary
- remove the CDATA wrapper from the generated inline script so browsers execute the report logic

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin because of 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_b_68e610f82084832580c42c48c5387278